### PR TITLE
doc: Fixed appnote URL's

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 embARC Audio
 =====
-![](https://embarc.org/images/icons/icon_audio.jpg)  
+![](https://foss-for-synopsys-dwc-arc-processors.github.io/images/icons/icon_audio.jpg)  
 ###### This repository contains source code of voice and audio codecs, test library and documentation.
 ## Release notes
 The following codecs were tuned for using MWDT compiler on processors families ARC EM/HS4xD voice audio:


### PR DESCRIPTION
We used to host embarc.org web-site on GitHub.io platform, but now we moved to a stand-alone solution.

Signed-off-by: Jingru Wang <jingru@synopsys.com>